### PR TITLE
fix: modify "AudioContext" to "window.AudioContext" for Safari

### DIFF
--- a/dist/AudioContext.js
+++ b/dist/AudioContext.js
@@ -1,1 +1,1 @@
-export default AudioContext || webkitAudioContext;
+export default window.AudioContext || window.webkitAudioContext;


### PR DESCRIPTION
The page shows error in safari when the page is ready. Modifying "AudioContext" to "window.AudioContext" can avoid it.